### PR TITLE
Remove incorrect is_key_block function

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -863,10 +863,6 @@ impl BlockExtra {
     pub fn set_ref_shard_blocks(&mut self, value: RefShardBlocks) {
         self.ref_shard_blocks = value;
     }
-
-    pub fn is_key_block(&self) -> bool {
-        self.custom.is_some()
-    }
 }
 
 const BLOCK_EXTRA_TAG: u32 = 0x4a33f6fd;


### PR DESCRIPTION
Hi there

I've noticed `BlockExtra::is_key_block` function works wrong.

The function is quite simple and only checks if `custom` field is present.

But it seems `custom` field presented for all masterchain blocks (it's type `McBlockExtra` humbly hints that)

I've checked on few hundreds master blocks and it exists everywhere (however I didn't test it on shard blocks)

So the only proper way to check if presented master block is key_block is to unpack `McBlockExtra` and check if `config` field is presented.

As far as it produces hidden costs (unpacking), I propose just remove `is_key_block` function from `BlockExtra` to avoid confusion

Please let me know if you need some proofs or examples